### PR TITLE
fix: update findById return type to Project and add description in test case

### DIFF
--- a/src/domain/repositories/project.repository.ts
+++ b/src/domain/repositories/project.repository.ts
@@ -24,7 +24,7 @@ export interface ProjectRepositoryType {
 export class ProjectRepository implements ProjectRepositoryType {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findById(id: string): Promise<ProjectDTO | null> {
+  async findById(id: string): Promise<Project | null> {
     return this.prisma.project.findUnique({
       where: { id },
     });

--- a/test/repositories/projectsRepository.test.ts
+++ b/test/repositories/projectsRepository.test.ts
@@ -38,6 +38,7 @@ describe('ProjectRepository', () => {
     testProject = await projectRepository.create({
       name: 'Test Project',
       ownerId: testUser.id,
+      description: 'Test Description',
     });
 
     expect(testProject).toBeDefined();


### PR DESCRIPTION
This pull request includes changes to the `ProjectRepository` and its corresponding tests to improve type usage and add a new property to the test project creation.

Improvements to type usage:

* [`src/domain/repositories/project.repository.ts`](diffhunk://#diff-646d06d5377b3cfcb5d7951adb22b4b84db142bf88ed75b61cd343ec89616645L27-R27): Changed the return type of the `findById` method from `ProjectDTO` to `Project`.

Enhancements to test project creation:

* [`test/repositories/projectsRepository.test.ts`](diffhunk://#diff-1557314f8ab8b90bb378052a32421ae159b691db5d761ac4e897de1e900acc57R41): Added a `description` property to the test project creation.