### PR TITLE
Feat/refresh token

### DIFF
--- a/integration-test/crud.test.ts
+++ b/integration-test/crud.test.ts
@@ -15,6 +15,7 @@ describe('Kanban API - Integration Tests', () => {
   let app: INestApplication;
   let prisma: PrismaService;
   let token: string;
+  // let refreshToken: string;
   let projectId: string;
   let taskId: string;
   let userId: string;
@@ -54,7 +55,8 @@ describe('Kanban API - Integration Tests', () => {
         password: 'password123',
       });
       expect(res.status).toBe(201);
-      token = res.body.token;
+      token = res.body.accessToken;
+      // refreshToken = res.body.refreshToken;
       expect(token).toBeDefined();
     });
   });

--- a/integration-test/relations.test.ts
+++ b/integration-test/relations.test.ts
@@ -61,11 +61,11 @@ describe('Kanban API - Integration Tests', () => {
   it('should register users', async () => {
     const res1 = await registerUser(user1);
     userId1 = res1.user.id;
-    token = res1.token;
+    token = res1.accessToken;
 
     const res2 = await registerUser(user2);
     userId2 = res2.user.id;
-    token2 = res2.token;
+    token2 = res2.accessToken;
   });
 
   it('should authenticate a user and return a token', async () => {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start:prod": "node dist/src/main",
     "prisma:migrate": "prisma migrate dev --schema=src/infrastructure/database/prisma/schema.prisma",
     "prisma:generate": "prisma generate --schema=src/infrastructure/database/prisma/schema.prisma",
+    "prisma:deploy": "prisma migrate deploy --schema=src/infrastructure/database/prisma/schema.prisma",
     "prisma:studio": "prisma studio --schema=src/infrastructure/database/prisma/schema.prisma",
     "prisma:reset": "prisma migrate reset --schema=src/infrastructure/database/prisma/schema.prisma",
     "prisma:seed": "ts-node src/infrastructure/database/prisma/seed.ts",

--- a/src/application/use-cases/auth/create-token.use-case.ts
+++ b/src/application/use-cases/auth/create-token.use-case.ts
@@ -1,16 +1,33 @@
 import { UserResponse } from '@/domain/dto/auth/auth-reponse.dto';
+import { RefreshTokenRepository } from '@/domain/repositories/refreshToken.repository';
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class CreateTokenUseCase {
-  constructor(private readonly jwtService: JwtService) {}
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly refreshTokenRepository: RefreshTokenRepository,
+  ) {}
 
-  public async execute(user: UserResponse): Promise<string> {
-    return await this.jwtService.signAsync({
+  public async execute(
+    user: UserResponse,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const accessToken = await this.jwtService.signAsync({
       id: user.id,
       email: user.email,
       role: user.role,
     });
+
+    const refreshToken = uuidv4();
+
+    await this.refreshTokenRepository.create({
+      token: refreshToken,
+      userId: user.id,
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
+    });
+
+    return { accessToken, refreshToken };
   }
 }

--- a/src/application/use-cases/auth/login.use-case.ts
+++ b/src/application/use-cases/auth/login.use-case.ts
@@ -25,8 +25,9 @@ export class LoginUseCase {
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    const token = await this.createTokenUseCase.execute(user);
+    const { accessToken, refreshToken } =
+      await this.createTokenUseCase.execute(user);
 
-    return { user, token };
+    return { user, accessToken, refreshToken };
   }
 }

--- a/src/application/use-cases/auth/refresh-token.use-case.ts
+++ b/src/application/use-cases/auth/refresh-token.use-case.ts
@@ -1,0 +1,51 @@
+// src/application/use-cases/auth/refresh-token.use-case.ts
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { v4 as uuidv4 } from 'uuid';
+import { RefreshTokenRepository } from '@/domain/repositories/refreshToken.repository';
+import { UserRepository } from '@/domain/repositories/user.repository';
+import { AuthResponseDto } from '@/domain/dto/auth/auth-reponse.dto';
+
+@Injectable()
+export class RefreshTokenUseCase {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly refreshToken: RefreshTokenRepository,
+    private readonly userRepo: UserRepository,
+  ) {}
+
+  public async execute(refreshToken: string): Promise<AuthResponseDto> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const session = await this.refreshToken.findByToken(refreshToken);
+
+    if (!session || session.expiresAt < new Date()) {
+      throw new UnauthorizedException('Refresh token invalid or expired');
+    }
+
+    const user = await this.userRepo.findById(session.userId as string);
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    const accessToken = await this.jwtService.signAsync({
+      id: user.id,
+      email: user.email,
+      role: user.role,
+    });
+
+    const newRefreshToken = uuidv4();
+    await this.refreshToken.create({
+      token: newRefreshToken,
+      userId: user.id,
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7), // 7 dias
+    });
+
+    await this.refreshToken.delete(refreshToken);
+
+    return {
+      user,
+      accessToken,
+      refreshToken: newRefreshToken,
+    };
+  }
+}

--- a/src/application/use-cases/auth/register.use-case.ts
+++ b/src/application/use-cases/auth/register.use-case.ts
@@ -35,8 +35,9 @@ export class RegisterUseCase {
       role: 'USER',
     });
 
-    const token = await this.createTokenUseCase.execute(user);
+    const { accessToken, refreshToken } =
+      await this.createTokenUseCase.execute(user);
 
-    return { user, token };
+    return { user, accessToken, refreshToken };
   }
 }

--- a/src/domain/dto/auth/auth-reponse.dto.ts
+++ b/src/domain/dto/auth/auth-reponse.dto.ts
@@ -19,5 +19,8 @@ export class AuthResponseDto {
   user: Omit<UserResponse, 'password'>;
 
   @ApiProperty()
-  token: string;
+  accessToken: string;
+
+  @ApiProperty()
+  refreshToken: string;
 }

--- a/src/domain/dto/auth/create-refresh-token.dto.ts
+++ b/src/domain/dto/auth/create-refresh-token.dto.ts
@@ -1,0 +1,25 @@
+import { IsUUID, IsDate, IsNotEmpty, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateRefreshTokenDto {
+  @ApiProperty({
+    description: 'Id of the user relationed to the user to the id',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  userId: string;
+
+  @ApiProperty({ description: 'The refresh token' })
+  @IsString()
+  token: string;
+
+  @IsDate()
+  @Type(() => Date)
+  expiresAt: Date;
+
+  constructor(partial: Partial<CreateRefreshTokenDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/src/domain/dto/auth/refresh-reponse.dto.ts
+++ b/src/domain/dto/auth/refresh-reponse.dto.ts
@@ -1,0 +1,7 @@
+// src/domain/dto/auth/refresh-token.dto.ts
+import { IsString } from 'class-validator';
+
+export class RefreshTokenDto {
+  @IsString()
+  refreshToken: string;
+}

--- a/src/domain/repositories/refreshToken.repository.ts
+++ b/src/domain/repositories/refreshToken.repository.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/infrastructure/database/prisma.service';
+import { RefreshToken } from '@prisma/client';
+import { CreateRefreshTokenDto } from '../dto/auth/create-refresh-token.dto';
+
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+type RefreshTokenResult = RefreshToken | null;
+
+interface RefreshTokenRepositoryType {
+  create(data: CreateRefreshTokenDto): Promise<RefreshToken>;
+  findByToken(token: string): Promise<RefreshTokenResult>;
+  delete(id: string): Promise<RefreshToken>;
+}
+
+@Injectable()
+export class RefreshTokenRepository implements RefreshTokenRepositoryType {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(data: CreateRefreshTokenDto): Promise<RefreshToken> {
+    return this.prisma.refreshToken.create({
+      data,
+    });
+  }
+
+  async findByToken(token: string): Promise<RefreshTokenResult> {
+    return this.prisma.refreshToken.findUnique({
+      where: { token },
+    });
+  }
+
+  async delete(token: string): Promise<RefreshToken> {
+    return this.prisma.refreshToken.delete({
+      where: { token },
+    });
+  }
+}

--- a/src/infrastructure/database/prisma/migrations/20250429232445_adding_refresh_token_table_to_store_relation_with_opaque_token/migration.sql
+++ b/src/infrastructure/database/prisma/migrations/20250429232445_adding_refresh_token_table_to_store_relation_with_opaque_token/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_token_key" ON "RefreshToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/infrastructure/database/prisma/schema.prisma
+++ b/src/infrastructure/database/prisma/schema.prisma
@@ -20,6 +20,17 @@ model User {
   Project Project[]
 
   Task Task[]
+
+  refreshToken RefreshToken[]
+}
+
+model RefreshToken {
+  id        String   @id @default(uuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  token     String   @unique
+  createdAt DateTime @default(now())
+  expiresAt DateTime
 }
 
 model Project {

--- a/src/infrastructure/http/controllers/auth/auth.controller.ts
+++ b/src/infrastructure/http/controllers/auth/auth.controller.ts
@@ -5,10 +5,15 @@ import { LoginUseCase } from '@/application/use-cases/auth/login.use-case';
 import { RegisterUseCase } from '@/application/use-cases/auth/register.use-case';
 import { RegisterDto } from '@/domain/dto/auth/register.dto';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { RefreshTokenDto } from '@/domain/dto/auth/refresh-reponse.dto';
+import { RefreshTokenUseCase } from '@/application/use-cases/auth/refresh-token.use-case';
 
 interface AuthControllerType {
   login: (loginDto: LoginDto) => Promise<AuthResponseDto>;
   register: (registerDto: RegisterDto) => Promise<AuthResponseDto>;
+  refreshToken: (refreshTokenDto: {
+    refreshToken: string;
+  }) => Promise<AuthResponseDto>;
 }
 
 @ApiTags('Authentication')
@@ -17,6 +22,7 @@ export class AuthController implements AuthControllerType {
   constructor(
     private readonly loginUseCase: LoginUseCase,
     private readonly registerUseCase: RegisterUseCase,
+    private readonly refreshTokenUseCase: RefreshTokenUseCase,
   ) {}
 
   @Post('login')
@@ -77,5 +83,20 @@ export class AuthController implements AuthControllerType {
   @ApiBody({ type: RegisterDto })
   async register(@Body() registerDto: RegisterDto): Promise<AuthResponseDto> {
     return this.registerUseCase.execute(registerDto);
+  }
+
+  @Post('refresh')
+  @ApiOperation({ summary: 'Refresh token - renew access and refresh tokens' })
+  @ApiResponse({
+    status: 200,
+    description: 'Tokens renewed successfully',
+    type: AuthResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Invalid or expired refresh token' })
+  @ApiBody({ type: RefreshTokenDto })
+  async refreshToken(
+    @Body() { refreshToken }: RefreshTokenDto,
+  ): Promise<AuthResponseDto> {
+    return this.refreshTokenUseCase.execute(refreshToken);
   }
 }

--- a/src/infrastructure/http/controllers/auth/auth.controller.ts
+++ b/src/infrastructure/http/controllers/auth/auth.controller.ts
@@ -34,7 +34,8 @@ export class AuthController implements AuthControllerType {
           role: 'USER',
           createdAt: '2021-09-01T00:00:00.000Z',
         },
-        token: 'hashedtoken',
+        accessToken: 'hashedJWT',
+        refreshToken: 'hasheduuidv4',
       },
     },
   })
@@ -68,7 +69,6 @@ export class AuthController implements AuthControllerType {
           role: 'USER',
           createdAt: '2021-09-01T00:00:00.000Z',
         },
-        token: 'hashedtoken',
       },
     },
   })

--- a/src/infrastructure/http/controllers/auth/auth.module.ts
+++ b/src/infrastructure/http/controllers/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { PrismaService } from '@/infrastructure/database/prisma.service';
 import { JwtModule } from '@nestjs/jwt';
 import { CreateTokenUseCase } from '@/application/use-cases/auth/create-token.use-case';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { RefreshTokenRepository } from '@/domain/repositories/refreshToken.repository';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
     LoginUseCase,
     RegisterUseCase,
     UserRepository,
+    RefreshTokenRepository,
     PrismaService,
   ],
   controllers: [AuthController],


### PR DESCRIPTION
This pull request introduces support for refresh tokens in the authentication flow, enhancing security and enabling token renewal. Key changes include updates to the token generation logic, the addition of a refresh token repository, and modifications to the API to support token refreshing.

### Authentication Enhancements:
* [`src/application/use-cases/auth/create-token.use-case.ts`](diffhunk://#diff-c28b618620e86eddc404935c6225f9ea3056be722ea178c0817c63f8515b2167R2-R31): Updated `CreateTokenUseCase` to generate both access and refresh tokens, storing the refresh token in the database with an expiration date.
* `src/application/use-cases/auth/login.use-case.ts`, `src/application/use-cases/auth/register.use-case.ts`: Modified login and registration flows to return both access and refresh tokens. [[1]](diffhunk://#diff-277086c75aa6111b17bbe0729bd04079e9563fec4c4325092e5736cfe3c68706L28-R31) [[2]](diffhunk://#diff-cb56e4f116ad59d47c3e53b5ffa2ad99d5c2078f121bf606e524b58e11a8f249L38-R41)
* [`src/application/use-cases/auth/refresh-token.use-case.ts`](diffhunk://#diff-be98a9898d3da12898c208f739f4d9955efd069840de61f84c248a8923c6677cR1-R51): Added a new `RefreshTokenUseCase` to validate and renew access and refresh tokens.

### API Updates:
* [`src/infrastructure/http/controllers/auth/auth.controller.ts`](diffhunk://#diff-e0b45a66a6031c4204bb88886261c23e2c1a5be974e1103801d00f915137b425R8-R16): Added a new `POST /refresh` endpoint to handle token renewal, using the `RefreshTokenUseCase`. Updated API responses to include both access and refresh tokens. [[1]](diffhunk://#diff-e0b45a66a6031c4204bb88886261c23e2c1a5be974e1103801d00f915137b425R8-R16) [[2]](diffhunk://#diff-e0b45a66a6031c4204bb88886261c23e2c1a5be974e1103801d00f915137b425R87-R101)

### Database and Repository Changes:
* [`src/infrastructure/database/prisma/schema.prisma`](diffhunk://#diff-913dbe9c5bd2dd7c4d78a8a226fb3c8b382c40969f18c1476ed547fa32c0fb46R23-R33): Added a `RefreshToken` model to store refresh tokens with user associations and expiration dates.
* [`src/domain/repositories/refreshToken.repository.ts`](diffhunk://#diff-26e760fb3600f32b04aaaec2936f85f432e8def3c8ad160e7f5b579664cad26fR1-R36): Implemented a repository for managing refresh tokens, including creation, lookup, and deletion.
* [`src/infrastructure/database/prisma/migrations/20250429232445_adding_refresh_token_table_to_store_relation_with_opaque_token/migration.sql`](diffhunk://#diff-2c599dba819eb793d09a077c3a8e036780f6e4e5c860f01cd65dda51bed7a2e2R1-R16): Added a database migration to create the `RefreshToken` table with necessary constraints and indices.

### DTO and Integration Test Updates:
* [`src/domain/dto/auth/auth-reponse.dto.ts`](diffhunk://#diff-5983359e659c5360cc0b051534a63633194557e5fce72619e578235392513101L22-R25): Updated `AuthResponseDto` to include `accessToken` and `refreshToken` fields.
* `integration-test/crud.test.ts`, `integration-test/relations.test.ts`: Updated integration tests to reflect the new token structure (`accessToken` and `refreshToken`). [[1]](diffhunk://#diff-2a69a63210c132dcd492ab4385eb05b3a904837d5a80a72089081535d39a721dR18) [[2]](diffhunk://#diff-4d2eadf8aa727ab2705d7c683c278c335fe366f82b498162578503a05918c920L64-R68)

### Miscellaneous:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17): Added a new `prisma:deploy` script for deploying Prisma migrations.