### PR TITLE
fix: add RefreshTokenUseCase to auth module

### DIFF
--- a/src/infrastructure/http/controllers/auth/auth.module.ts
+++ b/src/infrastructure/http/controllers/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { CreateTokenUseCase } from '@/application/use-cases/auth/create-token.use-case';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { RefreshTokenRepository } from '@/domain/repositories/refreshToken.repository';
+import { RefreshTokenUseCase } from '@/application/use-cases/auth/refresh-token.use-case';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { RefreshTokenRepository } from '@/domain/repositories/refreshToken.repos
     CreateTokenUseCase,
     LoginUseCase,
     RegisterUseCase,
+    RefreshTokenUseCase,
     UserRepository,
     RefreshTokenRepository,
     PrismaService,

--- a/test/controllers/auth/login.test.ts
+++ b/test/controllers/auth/login.test.ts
@@ -4,6 +4,7 @@ import { LoginUseCase } from '@/application/use-cases/auth/login.use-case';
 import { RegisterUseCase } from '@/application/use-cases/auth/register.use-case';
 import { JwtService } from '@nestjs/jwt';
 import { AuthResponseDto } from '@/domain/dto/auth/auth-reponse.dto';
+import { RefreshTokenUseCase } from '@/application/use-cases/auth/refresh-token.use-case';
 
 describe('AuthController - Login', () => {
   let authController: AuthController;
@@ -27,6 +28,10 @@ describe('AuthController - Login', () => {
           provide: JwtService,
           useValue: { sign: jest.fn() },
         },
+        {
+          provide: RefreshTokenUseCase,
+          useValue: { execute: jest.fn() },
+        },
       ],
     }).compile();
 
@@ -37,7 +42,8 @@ describe('AuthController - Login', () => {
 
   it('should successfully login and return a token', async () => {
     const mockToken: AuthResponseDto = {
-      token: 'token',
+      accessToken: 'token',
+      refreshToken: 'refreshToken',
       user: {
         id: '1',
         email: '',

--- a/test/controllers/auth/register.test.ts
+++ b/test/controllers/auth/register.test.ts
@@ -4,6 +4,7 @@ import { RegisterUseCase } from '@/application/use-cases/auth/register.use-case'
 import { AuthResponseDto } from '@/domain/dto/auth/auth-reponse.dto';
 import { LoginUseCase } from '@/application/use-cases/auth/login.use-case';
 import { JwtService } from '@nestjs/jwt';
+import { RefreshTokenUseCase } from '@/application/use-cases/auth/refresh-token.use-case';
 
 describe('AuthController - Register', () => {
   let authController: AuthController;
@@ -24,6 +25,10 @@ describe('AuthController - Register', () => {
           },
         },
         {
+          provide: RefreshTokenUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        {
           provide: JwtService,
           useValue: { sign: jest.fn() },
         },
@@ -36,7 +41,8 @@ describe('AuthController - Register', () => {
 
   it('should successfully register a user', async () => {
     const mockUser: AuthResponseDto = {
-      token: 'mockToken',
+      accessToken: 'mockToken',
+      refreshToken: 'mockRefreshToken',
       user: {
         id: '1',
         email: 'test@email.com',


### PR DESCRIPTION
This pull request introduces the `RefreshTokenUseCase` to the authentication module and updates the associated tests to support and validate its functionality. The most important changes include adding the `RefreshTokenUseCase` to the module and test dependencies, as well as modifying the authentication response structure to include both access and refresh tokens.

### Updates to the Authentication Module:

* Added the `RefreshTokenUseCase` to the providers array in the `AuthModule`, ensuring it is available for dependency injection. (`src/infrastructure/http/controllers/auth/auth.module.ts`) [[1]](diffhunk://#diff-c6c0fc44e0422332105ac3176e7cde4505f8c828fefed052130fa29b8fa1fdecR11) [[2]](diffhunk://#diff-c6c0fc44e0422332105ac3176e7cde4505f8c828fefed052130fa29b8fa1fdecR31)

### Updates to Tests:

* Updated the `login.test.ts` and `register.test.ts` files to include `RefreshTokenUseCase` as a mocked dependency for testing purposes. (`test/controllers/auth/login.test.ts`, `test/controllers/auth/register.test.ts`) [[1]](diffhunk://#diff-1c7de7ccb3f16b0d06990f762db5bbdcf9074ffc1ee34229ff5f2ba607546795R7) [[2]](diffhunk://#diff-1c7de7ccb3f16b0d06990f762db5bbdcf9074ffc1ee34229ff5f2ba607546795R31-R34) [[3]](diffhunk://#diff-647e5340192f65620b4961f588ba71f451e5214beb335566d340a08bb8ffb446R7) [[4]](diffhunk://#diff-647e5340192f65620b4961f588ba71f451e5214beb335566d340a08bb8ffb446R27-R30)
* Modified the mocked authentication response in the `login.test.ts` and `register.test.ts` files to include `accessToken` and `refreshToken` fields instead of a single `token`. (`test/controllers/auth/login.test.ts`, `test/controllers/auth/register.test.ts`) [[1]](diffhunk://#diff-1c7de7ccb3f16b0d06990f762db5bbdcf9074ffc1ee34229ff5f2ba607546795L40-R46) [[2]](diffhunk://#diff-647e5340192f65620b4961f588ba71f451e5214beb335566d340a08bb8ffb446L39-R45)