### PR TITLE
fix: remove unsafe assignment eslint disable and improve ID type handling in RefreshTokenUseCase

### DIFF
--- a/src/application/use-cases/auth/refresh-token.use-case.ts
+++ b/src/application/use-cases/auth/refresh-token.use-case.ts
@@ -15,14 +15,13 @@ export class RefreshTokenUseCase {
   ) {}
 
   public async execute(refreshToken: string): Promise<AuthResponseDto> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const session = await this.refreshToken.findByToken(refreshToken);
 
     if (!session || session.expiresAt < new Date()) {
       throw new UnauthorizedException('Refresh token invalid or expired');
     }
 
-    const user = await this.userRepo.findById(session.userId as string);
+    const user = await this.userRepo.findById(session.userId);
     if (!user) {
       throw new UnauthorizedException('User not found');
     }


### PR DESCRIPTION
This pull request includes a small improvement to the `RefreshTokenUseCase` class in the `src/application/use-cases/auth/refresh-token.use-case.ts` file. The change removes an unnecessary TypeScript ESLint comment and simplifies the `findById` method call by removing an explicit type cast.

* Removed an unused ESLint directive comment (`@typescript-eslint/no-unsafe-assignment`) and simplified the `findById` method call by removing the redundant `as string` type cast.